### PR TITLE
Grid overflow fix

### DIFF
--- a/src/components/color-select-display/color-select-display.css
+++ b/src/components/color-select-display/color-select-display.css
@@ -3,7 +3,8 @@
   grid-template-columns: repeat(6, minmax(0, 1fr));
   height: 10vw;
   margin-bottom: 2vw;
-  width: fit-content;
+  grid-row: "controls";
+  justify-self: center;
 }
 
 .color-select-square {

--- a/src/components/game-board/board.css
+++ b/src/components/game-board/board.css
@@ -2,9 +2,13 @@
   height: 25rem;
   border: #095256 solid 3px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  grid-template-columns: repeat(10, 5rem);
+  grid-row: "board";
+  justify-self: center;
 }
 .game-container {
   display: grid;
-  justify-content: center;
+  grid-template-areas:
+    "controls"
+    "board";
 }

--- a/src/components/game-board/board.css
+++ b/src/components/game-board/board.css
@@ -1,6 +1,6 @@
 .game-board {
   height: 25rem;
-  outline: #095256 solid 3px;
+  border: #095256 solid 3px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
 }

--- a/src/components/guess-column/guess-column.css
+++ b/src/components/guess-column/guess-column.css
@@ -2,7 +2,3 @@
   display: grid;
   grid-template-rows: repeat(5, minmax(0, 1fr));
 }
-
-.guess-column:not(:last-child) {
-  outline: #095256 solid 1px;
-}

--- a/src/components/guess-entry/guess-entry.css
+++ b/src/components/guess-entry/guess-entry.css
@@ -4,7 +4,7 @@
 }
 
 .guess-entry {
-  outline: #095256 solid 1px;
+  border: #095256 solid 1px;
 }
 
 .r {

--- a/src/components/guess-validator/guess-validator.css
+++ b/src/components/guess-validator/guess-validator.css
@@ -1,12 +1,15 @@
 .guess-validator {
   display: grid;
+  overflow: hidden;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: auto;
   grid-template-areas:
     "top-left top-right"
     "bottom-left bottom-right";
 }
 
 .validator-border {
-  outline: #095256 solid 1px;
+  border: #095256 solid 1px;
 }
 
 .correct {


### PR DESCRIPTION
Here's my alternative fix to the issue of the grid cells overflowing the container. I think it simply had to do with the css `overflow` property not being set.

## Screenshots

Here are comparison screenshots between my fix and the other PR. There are some sizing differences that I didn't pull in, but you can see also that the text on the end isn't breaking out of the container now either.
[Flexbox fix](#15):
<img width="1582" alt="Screenshot 2023-01-01 at 8 20 42 PM" src="https://user-images.githubusercontent.com/621865/210189684-07043ea4-c026-47d2-99a6-b5d0f086f5e7.png">

My solution:
<img width="1582" alt="Screenshot 2023-01-01 at 8 17 18 PM" src="https://user-images.githubusercontent.com/621865/210189686-1dbc2a2f-5a3c-4c91-8a47-77fccc9853b0.png">

The `overflow` trick would probably fix the text overflow in the flexbox solution as well, but the point is this is an overflow issue, not a grid issue.

## Possible issue

The other thing I did in this PR was to change the `outline`s to `border`s. I did this both because I think borders are better to use by default, but also I _was_ seeing a weird rendering bug with the outlines where not all of them were being drawn on the screen. I have theories why that I won't go into here, but I didn't have that bug in the flexbox solution. So if using outlines over borders is important and we can't figure out a solution to my issue, that may be a reason to still switch to flexbox.

### Bonus points

Because my PR is a net reduction in lines of code 😆